### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.15.0"
+  - 16
 install:
   - npm install -g yarn
   - yarn install

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,6 +1,6 @@
-import "@testing-library/jest-dom";
+import '@testing-library/jest-dom';
 
-import { configure } from "enzyme";
-import Adapter from "enzyme-adapter-react-16";
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });


### PR DESCRIPTION
I ran into linting issues when I first checked out this project and it appears that the CI for this project has not run in quite a while:

![image](https://user-images.githubusercontent.com/23029903/122040775-94c04700-ce1b-11eb-9cf4-a9c58456e959.png)

The linting issues were fairly minor (wrong quotes on test setup), but the CI is actually failing tring to install dependancies that no longer support Node 8 (what the travis config currently uses).  I chose to go update to the latest and I've tested that `start`, `lint`, `test` and `build` commands all still work with this version.  If there are concerns about jumping from 8 to 16, we could look at an older supported version (perhaps 12).

I've also activated [travis-ci on this repo](https://travis-ci.org/github/OpenSourceRaidGuild/react-router-last-location) to get feedback on our changes as we go.