### PR TITLE
100% test coverage

### DIFF
--- a/src/RedirectWithoutLastLocation.spec.tsx
+++ b/src/RedirectWithoutLastLocation.spec.tsx
@@ -46,14 +46,14 @@ afterEach(() => setLastLocation(null))
 describe('RedirectWithoutLastLocation', () => {
   const runTest = () => {
     // Check if lastLocation is empty
-    screen.getAllByTestId(/last-location-pathname/i)
+    screen.getByTestId(/last-location-pathname/i)
     // Check if we are on the homepage
-    screen.getAllByRole('heading', {
+    screen.getByRole('heading', {
       name: /home/i
     })
 
     // Visit /about
-    userEvent.click(screen.getAllByText(/AboutLink/i)[0])
+    userEvent.click(screen.getByText(/AboutLink/i))
      
     // Check if we are on the /about
     screen.getAllByRole('heading', {
@@ -61,19 +61,17 @@ describe('RedirectWithoutLastLocation', () => {
     })
 
     // Check lastLocation
-    let pathName = screen.getAllByTestId(/last-location-pathname/i)
-    expect(pathName[pathName.length -1]).toHaveTextContent('/')
+    expect(screen.getByTestId(/last-location-pathname/i)).toHaveTextContent('/')
 
     // Visit /secret
-    userEvent.click(screen.getAllByText(/SecretLink/i)[0])
+    userEvent.click(screen.getByText(/SecretLink/i))
     // We Should be redirected back to homepage
-    screen.getAllByRole('heading', {
+    screen.getByRole('heading', {
       name: /home/i
     })
 
     // The lastLocation should point to /about
-    pathName = screen.getAllByTestId(/last-location-pathname/i)
-    expect(pathName[pathName.length -1]).toHaveTextContent('/about')
+    expect(screen.getByTestId(/last-location-pathname/i)).toHaveTextContent('/about')
   };
 
   describe('When `to` is passed as a string', () => {
@@ -84,11 +82,14 @@ describe('RedirectWithoutLastLocation', () => {
     });
   });
   describe('When `to` is passed as an object', () => {
-    rtlRender({
-      redirectTo: {
-        pathname: '/',
-      },
+    it('should store redirected route', () => {
+      rtlRender({
+        redirectTo: {
+          pathname: '/',
+        },
+      })
+      runTest();
+    });
     })
-    runTest();
-  });
+    
 });

--- a/src/useLastLocation.spec.tsx
+++ b/src/useLastLocation.spec.tsx
@@ -4,7 +4,8 @@ import { renderHook as rtlRenderHook, act } from '@testing-library/react-hooks';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import useLastLocation from './useLastLocation';
-import LastLocationProvider from './LastLocationProvider';
+import LastLocationProvider, { setLastLocation, getLastLocation } from './LastLocationProvider';
+import { LastLocationType } from './LastLocationContext';
 
 function renderHook(watchOnlyPathname = false) {
   const history = createMemoryHistory({
@@ -26,6 +27,7 @@ function renderHook(watchOnlyPathname = false) {
   };
 }
 
+afterEach(() => setLastLocation(null))
 describe('useLastLocation', () => {
   it('should have no last location on the first visit', async () => {
     const { result } = renderHook();
@@ -93,7 +95,7 @@ it('should do nothing if application is rerendered and location is the same', ()
     history.push('/test-1');
     history.push('/test-2');
   });
-
+  const getterLastPrev = getLastLocation() as Exclude<LastLocationType, null>
   const lastLocationPrev = (result.current as any).pathname;
   /**
      * This one is a bit tricky. I want to test case when `getDerivedStateFromProps` would be
@@ -101,8 +103,11 @@ it('should do nothing if application is rerendered and location is the same', ()
      * @see https://github.com/airbnb/enzyme/issues/1925#issuecomment-463248558
      */
   rerender();
+  const getterLastNext = getLastLocation() as Exclude<LastLocationType, null>
   const lastLocationNext = (result.current as any).pathname;
-
+  
+  expect(getterLastPrev.key).toBe(getterLastNext.key)
+  expect(getterLastPrev.pathname).toBe(getterLastNext.pathname)
   expect(lastLocationPrev).toBe(lastLocationNext);
 });
 


### PR DESCRIPTION
- setLastLocation was used previously
- 100% coverage - Moved Provider tests into useLastLocation - Tested lastLocation context Getter in rerendered test using it to check context key & pathname as well as the hook
